### PR TITLE
Expand detection error for future

### DIFF
--- a/Sources/Citadel/SSHKeyTypeDetection.swift
+++ b/Sources/Citadel/SSHKeyTypeDetection.swift
@@ -85,7 +85,7 @@ public enum SSHKeyDetectionError: LocalizedError, Equatable {
         case .invalidKeyFormat(let reason):
             return "The key string is not in a valid SSH-key format" + (reason.map { ": \($0)" } ?? "")
         case .unsupportedKeyType(let type):
-            return "The key type \(type ?? "") is not supported"
+            return "The key type is not supported" + (type.map { " (raw value: \($0))" } ?? "")
         case .invalidPrivateKeyFormat:
             return "The private key format is invalid or corrupted"
         case .malformedKey:

--- a/Sources/Citadel/SSHKeyTypeDetection.swift
+++ b/Sources/Citadel/SSHKeyTypeDetection.swift
@@ -55,7 +55,7 @@ public struct SSHKeyType: RawRepresentable, Equatable, Hashable, CaseIterable, C
 
 
 /// Errors that can occur during SSH key type detection.
-public enum SSHKeyDetectionError: LocalizedError {
+public enum SSHKeyDetectionError: LocalizedError, Equatable {
     case invalidKeyFormat(reason: String? = nil)
     case unsupportedKeyType(type: String? = nil)
     case invalidPrivateKeyFormat
@@ -63,6 +63,22 @@ public enum SSHKeyDetectionError: LocalizedError {
     case encryptedPrivateKey              // key is encrypted, no pass-phrase handled yet
     case passphraseRequired               // caller gave none
     case incorrectPassphrase              // caller gave one, but it was wrong
+
+    // Equality only cares about the *case*, not the associated text.
+    public static func == (lhs: SSHKeyDetectionError, rhs: SSHKeyDetectionError) -> Bool {
+        switch (lhs, rhs) {
+        case (.invalidKeyFormat,       .invalidKeyFormat),
+             (.unsupportedKeyType,     .unsupportedKeyType),
+             (.invalidPrivateKeyFormat,.invalidPrivateKeyFormat),
+             (.malformedKey,           .malformedKey),
+             (.encryptedPrivateKey,    .encryptedPrivateKey),
+             (.passphraseRequired,     .passphraseRequired),
+             (.incorrectPassphrase,    .incorrectPassphrase):
+            return true
+        default:
+            return false
+        }
+    }
 
     public var errorDescription: String? {
         switch self {

--- a/Tests/CitadelTests/KeyTests.swift
+++ b/Tests/CitadelTests/KeyTests.swift
@@ -170,7 +170,7 @@ final class KeyTests: XCTestCase {
         XCTAssertThrowsError(try SSHKeyDetection.detectPublicKeyType(from: invalidKey)) { error in
             XCTAssertTrue(error is SSHKeyDetectionError)
             if let sshError = error as? SSHKeyDetectionError {
-                XCTAssertEqual(sshError, .invalidKeyFormat(reason: nil))
+                XCTAssertEqual(sshError, .invalidKeyFormat())
             }
         }
         

--- a/Tests/CitadelTests/KeyTests.swift
+++ b/Tests/CitadelTests/KeyTests.swift
@@ -170,7 +170,7 @@ final class KeyTests: XCTestCase {
         XCTAssertThrowsError(try SSHKeyDetection.detectPublicKeyType(from: invalidKey)) { error in
             XCTAssertTrue(error is SSHKeyDetectionError)
             if let sshError = error as? SSHKeyDetectionError {
-                XCTAssertEqual(sshError, .invalidKeyFormat)
+                XCTAssertEqual(sshError, .invalidKeyFormat(reason: nil))
             }
         }
         


### PR DESCRIPTION
This pull request enhances the `SSHKeyDetectionError` enum in `Sources/Citadel/SSHKeyTypeDetection.swift` to include more detailed error cases and associated data, improving error handling and debugging capabilities. Additionally, it updates related methods and tests to align with these changes.

### Enhancements to `SSHKeyDetectionError`:

* Added new error cases: `encryptedPrivateKey`, `passphraseRequired`, and `incorrectPassphrase`. These provide more granular error reporting for private key issues.
* Modified existing cases `invalidKeyFormat` and `unsupportedKeyType` to include optional associated data (`reason` and `type`, respectively). This allows for more descriptive error messages.
* Implemented a custom equality operator (`==`) that compares only the case, ignoring associated data.
* Updated the `errorDescription` property to include associated data in error messages when available.

### Updates to error throwing:

* Updated the `SSHKeyDetection.detectPublicKeyType` method to include a `reason` when throwing the `invalidKeyFormat` error.
* Updated the `SSHKeyDetection.detectPrivateKeyType` method to include the unsupported key type in the `unsupportedKeyType` error.

### Test adjustments:

* Modified the `KeyTests` test case to verify the updated `invalidKeyFormat` error with an optional `reason` parameter.